### PR TITLE
no spaces in plugin name

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-name: Lobby Fly
+name: LobbyFly
 version: '${project.version}'
 main: org.baipiaocn.lobby_fly.LobbyFly
 commands:


### PR DESCRIPTION
having a space in the plugin name in plugin.yml causes the plugin to not load on the latest version of paper